### PR TITLE
Add extraction of Connectivity Search PathCount table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ cython_debug/
 
 # data ignores
 src/bioprocess_metapath_to_gene_pval_and_dwpc/data/results
+*.sql.gz
+*.parquet
+*.duckdb
+copy_data*.sql

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,43 +3,48 @@
 default_language_version:
   python: python3.11
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-      - id: detect-private-key
-  - repo: https://github.com/tox-dev/pyproject-fmt
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: detect-private-key
+-   repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.5.0"
     hooks:
-      - id: pyproject-fmt
-  - repo: https://github.com/codespell-project/codespell
+    -   id: pyproject-fmt
+-   repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
-      - id: codespell
+    -   id: codespell
         exclude: |
           (?x)^(
               .*\.lock |
               .*\.csv
           )$
-  - repo: https://github.com/executablebooks/mdformat
+-   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.18
     hooks:
-      - id: mdformat
+    -   id: mdformat
         additional_dependencies:
-          - mdformat-gfm
-  - repo: https://github.com/adrienverge/yamllint
+        -   mdformat-gfm
+-   repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:
-      - id: yamllint
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.7.2"
+    -   id: yamllint
+        exclude: pre-commit-config.yaml
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.7.4"
     hooks:
-      - id: ruff-format
-      - id: ruff
-  - repo: https://github.com/rhysd/actionlint
+    -   id: ruff-format
+    -   id: ruff
+-   repo: https://github.com/rhysd/actionlint
     rev: v1.7.4
     hooks:
-      - id: actionlint
+    -   id: actionlint
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.6.0post1
+    hooks:
+    -   id: pre-commit-update

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Various data analysis performed using [Hetionet](https://het.io/), a [hetnet](ht
 1. Install package locally (e.g. `uv pip install -e ".[dev]"`).
 1. Run tests (e.g. `uv run poe test`, through [poethepoet](https://poethepoet.natn.io/index.html) task).
 1. Run various tasks (e.g. `uv run poe run_bioproc_gene_metapath_test`)
+
+## Tasks
+
+Poe the poet tasks may be run to help generate results without needing to run individual files or perform additional discovery within this project.
+You can show all available tasks with `uv run poe`.
+
+- Create Connectivity Search PathCount table: `uv run poe run_pathcount_extract`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ uv run python src/bioprocess_metapath_to_gene_pval_and_dwpc/gather_subset_data_m
 # run path count table extraction
 run_pathcount_extract.shell = """
 cd src/connectivity_search_PathCount_table
-source run.sh
+uv run python get_table.py
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "black>=24.10",
+  "duckdb>=1.1.3",
   "hetmatpy>=0.1",
   "ipywidgets>=8.1.5",
   "isort>=5.13.2",
@@ -85,7 +86,12 @@ test.shell = """
 uv run pre-commit run -a
 uv run pytest
 """
-#
+# run the gene metapath extraction
 run_bioproc_gene_metapath_test.shell = """
 uv run python src/bioprocess_metapath_to_gene_pval_and_dwpc/gather_subset_data_metapath_BPpGdAdG.py
+"""
+# run path count table extraction
+run_pathcount_extract.shell = """
+cd src/connectivity_search_PathCount_table
+source run.sh
 """

--- a/src/connectivity_search_PathCount_table/create_table.public.dj_hetmech_app_pathcount.sql
+++ b/src/connectivity_search_PathCount_table/create_table.public.dj_hetmech_app_pathcount.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.dj_hetmech_app_pathcount (
+    id integer NOT NULL,
+    path_count integer NOT NULL,
+    dwpc double precision NOT NULL,
+    p_value double precision,
+    metapath_id character varying(20) NOT NULL,
+    source_id integer NOT NULL,
+    target_id integer NOT NULL,
+    dgp_id integer NOT NULL,
+    CONSTRAINT dj_hetmech_app_pathcount_path_count_check CHECK ((path_count >= 0))
+);

--- a/src/connectivity_search_PathCount_table/get_table.ipynb
+++ b/src/connectivity_search_PathCount_table/get_table.ipynb
@@ -1,0 +1,368 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b6ea781c-e991-44ef-a0e2-84f4086144ca",
+   "metadata": {},
+   "source": [
+    "# Gather Connectivity Search `PathCount` Table\n",
+    "\n",
+    "Negar mentioned needing data from a PostgreSQL database archive, `connectivity-search-pg_dump.sql.gz`, which was created as part of https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .\n",
+    "The archive is available under https://zenodo.org/records/3978766 . Only the `PathCount` Table is needed in order to extract single metapaths at a time (needed for other work).\n",
+    "                                                                                                                  This PR was mentioned as a resource in case it's needed greenelab/connectivity-search-backend#79 .\n",
+    "                                                                                                                                                                                                           "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4ebd7bfa-357e-4033-8cd8-b430b75d706e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gzip\n",
+    "import pathlib\n",
+    "from typing import List, Optional\n",
+    "\n",
+    "import duckdb\n",
+    "import requests\n",
+    "from pyarrow import parquet\n",
+    "\n",
+    "from hetionet_utils.sql import extract_and_write_sql_block\n",
+    "\n",
+    "# create the data dir\n",
+    "pathlib.Path(\"data\").mkdir(exist_ok=True)\n",
+    "\n",
+    "# url for source data\n",
+    "url = \"https://zenodo.org/records/3978766/files/connectivity-search-pg_dump.sql.gz?download=1\"\n",
+    "# local archive file location\n",
+    "sql_file = \"data/connectivity-search-pg_dump.sql.gz\"\n",
+    "# table which is targeted within the sql archive above\n",
+    "target_table_name = \"public.dj_hetmech_app_pathcount\"\n",
+    "# duckdb filename\n",
+    "duckdb_filename = \"data/connectivity-search.duckdb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d6b8320a-b50e-487f-808e-4ada2e25b877",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# gather postgresql database archive\n",
+    "\n",
+    "# if the file doesn't exist, download it\n",
+    "if not pathlib.Path(sql_file).exists():\n",
+    "    # Download the file in streaming mode\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    response.raise_for_status()  # Check if the request was successful\n",
+    "\n",
+    "    # Write the response content to a file in chunks\n",
+    "    with open(output_file, \"wb\") as file:\n",
+    "        for chunk in response.iter_content(chunk_size=8192):\n",
+    "            if chunk:\n",
+    "                file.write(chunk)\n",
+    "\n",
+    "pathlib.Path(sql_file).exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "839d6ad3-1592-48ac-af8f-693d20bfca42",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CREATE TABLE public.auth_group (\n",
+      "\n",
+      "CREATE TABLE public.auth_group_permissions (\n",
+      "\n",
+      "CREATE TABLE public.auth_permission (\n",
+      "\n",
+      "CREATE TABLE public.auth_user (\n",
+      "\n",
+      "CREATE TABLE public.auth_user_groups (\n",
+      "\n",
+      "CREATE TABLE public.auth_user_user_permissions (\n",
+      "\n",
+      "CREATE TABLE public.dj_hetmech_app_degreegroupedpermutation (\n",
+      "\n",
+      "CREATE TABLE public.dj_hetmech_app_metanode (\n",
+      "\n",
+      "CREATE TABLE public.dj_hetmech_app_metapath (\n",
+      "\n",
+      "CREATE TABLE public.dj_hetmech_app_node (\n",
+      "\n",
+      "CREATE TABLE public.dj_hetmech_app_pathcount (\n",
+      "\n",
+      "CREATE TABLE public.django_admin_log (\n",
+      "\n",
+      "CREATE TABLE public.django_content_type (\n",
+      "\n",
+      "CREATE TABLE public.django_migrations (\n",
+      "\n",
+      "CREATE TABLE public.django_session (\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# show the tables\n",
+    "count = 0\n",
+    "with gzip.open(sql_file, \"rt\") as f:\n",
+    "    for line in f:\n",
+    "        # seek table creation lines\n",
+    "        if \"CREATE TABLE\" in line:\n",
+    "            print(line)\n",
+    "            count += 1\n",
+    "            # there are roughly 15 tables\n",
+    "            # so we break here to avoid further processing\n",
+    "            if count == 15:\n",
+    "                break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ba56b913-73ef-49a6-b77b-3a130544222e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'create_table.public.dj_hetmech_app_pathcount.sql'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# gather the create table statement\n",
+    "extract_and_write_sql_block(\n",
+    "    sql_file=sql_file,\n",
+    "    sql_start=f\"CREATE TABLE {target_table_name}\",\n",
+    "    sql_end=\";\",\n",
+    "    output_file=(create_table_file := f\"create_table.{target_table_name}.sql\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c93c66ec-6667-4c32-9b07-817402185cf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CREATE TABLE public.dj_hetmech_app_pathcount (\n",
+      "    id integer NOT NULL,\n",
+      "    path_count integer NOT NULL,\n",
+      "    dwpc double precision NOT NULL,\n",
+      "    p_value double precision,\n",
+      "    metapath_id character varying(20) NOT NULL,\n",
+      "    source_id integer NOT NULL,\n",
+      "    target_id integer NOT NULL,\n",
+      "    dgp_id integer NOT NULL,\n",
+      "    CONSTRAINT dj_hetmech_app_pathcount_path_count_check CHECK ((path_count >= 0))\n",
+      ");\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# show the create table statement\n",
+    "with open(create_table_file, \"r\") as create_file:\n",
+    "    print(\"\".join(create_file.readlines()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cdf1265e-3d33-40d0-b58e-7b33cfdbe636",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'copy_data.public.dj_hetmech_app_pathcount.sql'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# gather the data for the table\n",
+    "# note: we avoid printing the file below as it is\n",
+    "# relatively large at ~14.3 GB.\n",
+    "extract_and_write_sql_block(\n",
+    "    sql_file=sql_file,\n",
+    "    sql_start=f\"COPY {target_table_name}\",\n",
+    "    sql_end=\"\\\\.\",\n",
+    "    output_file=f\"copy_data.{target_table_name}.sql\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "52ef72d7-15db-4522-bc85-43be5e59b97b",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "CatalogException",
+     "evalue": "Catalog Error: Table with name \"dj_hetmech_app_pathcount\" already exists!",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mCatalogException\u001b[0m                          Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[27], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# create the table\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28;43;01mwith\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mduckdb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnect\u001b[49m\u001b[43m(\u001b[49m\u001b[43mduckdb_filename\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mas\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mddb\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mddb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcreate_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreplace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mpublic.\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[27], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# create the table\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m duckdb\u001b[38;5;241m.\u001b[39mconnect(duckdb_filename) \u001b[38;5;28;01mas\u001b[39;00m ddb:\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mddb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcreate_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreplace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mpublic.\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mCatalogException\u001b[0m: Catalog Error: Table with name \"dj_hetmech_app_pathcount\" already exists!"
+     ]
+    }
+   ],
+   "source": [
+    "# create the table\n",
+    "with duckdb.connect(duckdb_filename) as ddb:\n",
+    "    ddb.execute(create_sql.replace(\"public.\", \"\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "6f0e4ec8-c114-4ed9-9562-1ea5b166a61f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove the first and last line of the data to avoid conflicts with a load\n",
+    "# note: we use sed from a macos terminal, which may vary from system to system.\n",
+    "# sed was used here to help avoid unnecessary data duplication and complexity\n",
+    "# in processing through python.\n",
+    "!sed -i '' '1d;$d' copy_data.public.dj_hetmech_app_pathcount.sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "580954bb-513d-4e6b-8651-fe7d53665c41",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "39b7dd580f2c452d91b6a25a94f73af6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# copy the data from the file to duckdb database\n",
+    "# as tab-delimited file.\n",
+    "with duckdb.connect(duckdb_filename) as ddb:\n",
+    "    ddb.execute(\n",
+    "        \"\"\"\n",
+    "        COPY dj_hetmech_app_pathcount\n",
+    "        FROM 'copy_data.public.dj_hetmech_app_pathcount.sql'\n",
+    "        (DELIMITER '\\t', HEADER false);\n",
+    "        \"\"\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "be554e51-3001-44e5-87a1-cb3f5fb8645b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b61334adf2904962918e8d5f621e28cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# read and export data to parquet for ease of use\n",
+    "with duckdb.connect(duckdb_filename) as ddb:\n",
+    "    tbl_pathcount = ddb.execute(\n",
+    "        \"\"\"\n",
+    "        SELECT *\n",
+    "        FROM dj_hetmech_app_pathcount\n",
+    "        \"\"\"\n",
+    "    ).arrow()\n",
+    "\n",
+    "parquet.write_table(\n",
+    "    table=tbl_pathcount,\n",
+    "    where=\"data/dj_hetmech_app_pathcount.parquet\",\n",
+    "    # compress with zstd for higher compression than snappy\n",
+    "    compression=\"zstd\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "000a96e9-a52d-46ec-b4d5-8e52e0549dcb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/connectivity_search_PathCount_table/get_table.ipynb
+++ b/src/connectivity_search_PathCount_table/get_table.ipynb
@@ -7,15 +7,17 @@
    "source": [
     "# Gather Connectivity Search `PathCount` Table\n",
     "\n",
-    "Negar mentioned needing data from a PostgreSQL database archive, `connectivity-search-pg_dump.sql.gz`, which was created as part of https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .\n",
-    "The archive is available under https://zenodo.org/records/3978766 . Only the `PathCount` Table is needed in order to extract single metapaths at a time (needed for other work).\n",
-    "                                                                                                                  This PR was mentioned as a resource in case it's needed greenelab/connectivity-search-backend#79 .\n",
-    "                                                                                                                                                                                                           "
+    "Negar mentioned needing data from a PostgreSQL database archive,\n",
+    "`connectivity-search-pg_dump.sql.gz`, which was created as part of\n",
+    "https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .\n",
+    "The archive is available under https://zenodo.org/records/3978766 .\n",
+    "Only the `PathCount` Table is needed in order to extract single metapaths\n",
+    "at a time (needed for other work)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "4ebd7bfa-357e-4033-8cd8-b430b75d706e",
    "metadata": {},
    "outputs": [],
@@ -33,18 +35,27 @@
     "pathlib.Path(\"data\").mkdir(exist_ok=True)\n",
     "\n",
     "# url for source data\n",
-    "url = \"https://zenodo.org/records/3978766/files/connectivity-search-pg_dump.sql.gz?download=1\"\n",
+    "url = (\n",
+    "    \"https://zenodo.org/records/3978766/files/\"\n",
+    "    \"connectivity-search-pg_dump.sql.gz?download=1\"\n",
+    ")\n",
+    "\n",
     "# local archive file location\n",
     "sql_file = \"data/connectivity-search-pg_dump.sql.gz\"\n",
+    "\n",
+    "# expected number of tables within dump\n",
+    "expected_table_count = 15\n",
+    "\n",
     "# table which is targeted within the sql archive above\n",
     "target_table_name = \"public.dj_hetmech_app_pathcount\"\n",
+    "\n",
     "# duckdb filename\n",
     "duckdb_filename = \"data/connectivity-search.duckdb\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "d6b8320a-b50e-487f-808e-4ada2e25b877",
    "metadata": {},
    "outputs": [
@@ -54,7 +65,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -66,10 +77,12 @@
     "if not pathlib.Path(sql_file).exists():\n",
     "    # Download the file in streaming mode\n",
     "    response = requests.get(url, stream=True)\n",
-    "    response.raise_for_status()  # Check if the request was successful\n",
+    "\n",
+    "    # Check if the request was successful\n",
+    "    response.raise_for_status()\n",
     "\n",
     "    # Write the response content to a file in chunks\n",
-    "    with open(output_file, \"wb\") as file:\n",
+    "    with open(sql_file, \"wb\") as file:\n",
     "        for chunk in response.iter_content(chunk_size=8192):\n",
     "            if chunk:\n",
     "                file.write(chunk)\n",
@@ -79,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "839d6ad3-1592-48ac-af8f-693d20bfca42",
    "metadata": {},
    "outputs": [
@@ -131,23 +144,23 @@
     "            count += 1\n",
     "            # there are roughly 15 tables\n",
     "            # so we break here to avoid further processing\n",
-    "            if count == 15:\n",
+    "            if count == expected_table_count:\n",
     "                break"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "ba56b913-73ef-49a6-b77b-3a130544222e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'create_table.public.dj_hetmech_app_pathcount.sql'"
+       "True"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "c93c66ec-6667-4c32-9b07-817402185cf8",
    "metadata": {},
    "outputs": [
@@ -190,57 +203,67 @@
    "source": [
     "# show the create table statement\n",
     "with open(create_table_file, \"r\") as create_file:\n",
-    "    print(\"\".join(create_file.readlines()))"
+    "    create_sql = \"\".join(create_file.readlines())\n",
+    "\n",
+    "print(create_sql)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "cdf1265e-3d33-40d0-b58e-7b33cfdbe636",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'copy_data.public.dj_hetmech_app_pathcount.sql'"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# gather the data for the table\n",
-    "# note: we avoid printing the file below as it is\n",
-    "# relatively large at ~14.3 GB.\n",
     "extract_and_write_sql_block(\n",
     "    sql_file=sql_file,\n",
     "    sql_start=f\"COPY {target_table_name}\",\n",
     "    sql_end=\"\\\\.\",\n",
-    "    output_file=f\"copy_data.{target_table_name}.sql\",\n",
+    "    output_file=(copy_data_file := f\"copy_data.{target_table_name}.sql\"),\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
+   "id": "9758cb12-d8f8-48fd-948d-ba3c9e57c070",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace the first and last lines of the copy file\n",
+    "# as these are the header and data termination lines\n",
+    "# which have no actual values.\n",
+    "input_file = pathlib.Path(copy_data_file)\n",
+    "# Temporary file with .tmp extension\n",
+    "temp_file = input_file.with_suffix(\".tmp\")\n",
+    "\n",
+    "with input_file.open(\"r\") as infile, temp_file.open(\"w\") as outfile:\n",
+    "    # Skip the first line\n",
+    "    first_line = next(infile, None)\n",
+    "\n",
+    "    # Only proceed if the file is not empty\n",
+    "    if first_line is not None:\n",
+    "        # Start with the second line\n",
+    "        prev_line = next(infile, None)\n",
+    "        for line in infile:\n",
+    "            # Write the previous line\n",
+    "            outfile.write(prev_line)\n",
+    "            # Update the previous line buffer\n",
+    "            prev_line = line\n",
+    "\n",
+    "        # Note: the last line is in `prev_line` and is not written\n",
+    "\n",
+    "# Replace the original file with the temporary file\n",
+    "temp_file.replace(input_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "52ef72d7-15db-4522-bc85-43be5e59b97b",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "CatalogException",
-     "evalue": "Catalog Error: Table with name \"dj_hetmech_app_pathcount\" already exists!",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mCatalogException\u001b[0m                          Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[27], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# create the table\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28;43;01mwith\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mduckdb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnect\u001b[49m\u001b[43m(\u001b[49m\u001b[43mduckdb_filename\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mas\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mddb\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mddb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcreate_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreplace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mpublic.\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[27], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# create the table\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m duckdb\u001b[38;5;241m.\u001b[39mconnect(duckdb_filename) \u001b[38;5;28;01mas\u001b[39;00m ddb:\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mddb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcreate_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreplace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mpublic.\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mCatalogException\u001b[0m: Catalog Error: Table with name \"dj_hetmech_app_pathcount\" already exists!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create the table\n",
     "with duckdb.connect(duckdb_filename) as ddb:\n",
@@ -249,47 +272,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "6f0e4ec8-c114-4ed9-9562-1ea5b166a61f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# remove the first and last line of the data to avoid conflicts with a load\n",
-    "# note: we use sed from a macos terminal, which may vary from system to system.\n",
-    "# sed was used here to help avoid unnecessary data duplication and complexity\n",
-    "# in processing through python.\n",
-    "!sed -i '' '1d;$d' copy_data.public.dj_hetmech_app_pathcount.sql"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "580954bb-513d-4e6b-8651-fe7d53665c41",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "39b7dd580f2c452d91b6a25a94f73af6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# copy the data from the file to duckdb database\n",
     "# as tab-delimited file.\n",
     "with duckdb.connect(duckdb_filename) as ddb:\n",
     "    ddb.execute(\n",
-    "        \"\"\"\n",
+    "        f\"\"\"\n",
     "        COPY dj_hetmech_app_pathcount\n",
-    "        FROM 'copy_data.public.dj_hetmech_app_pathcount.sql'\n",
+    "        FROM '{copy_data_file}'\n",
     "        (DELIMITER '\\t', HEADER false);\n",
     "        \"\"\"\n",
     "    )"
@@ -297,27 +291,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "be554e51-3001-44e5-87a1-cb3f5fb8645b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b61334adf2904962918e8d5f621e28cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# read and export data to parquet for ease of use\n",
+    "# read and export data to parquet for simpler use\n",
     "with duckdb.connect(duckdb_filename) as ddb:\n",
     "    tbl_pathcount = ddb.execute(\n",
     "        \"\"\"\n",
@@ -333,14 +312,6 @@
     "    compression=\"zstd\",\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "000a96e9-a52d-46ec-b4d5-8e52e0549dcb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/connectivity_search_PathCount_table/get_table.ipynb
+++ b/src/connectivity_search_PathCount_table/get_table.ipynb
@@ -210,10 +210,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "cdf1265e-3d33-40d0-b58e-7b33cfdbe636",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# gather the data for the table\n",
     "extract_and_write_sql_block(\n",
@@ -226,10 +237,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "9758cb12-d8f8-48fd-948d-ba3c9e57c070",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('copy_data.public.dj_hetmech_app_pathcount.sql')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# replace the first and last lines of the copy file\n",
     "# as these are the header and data termination lines\n",
@@ -260,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "52ef72d7-15db-4522-bc85-43be5e59b97b",
    "metadata": {},
    "outputs": [],
@@ -272,10 +294,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "580954bb-513d-4e6b-8651-fe7d53665c41",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4a802e63b214f49bcb66d52ee7f1ed0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# copy the data from the file to duckdb database\n",
     "# as tab-delimited file.\n",
@@ -291,10 +328,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "be554e51-3001-44e5-87a1-cb3f5fb8645b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e98906c3dfa04889881701d7857554e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# read and export data to parquet for simpler use\n",
     "with duckdb.connect(duckdb_filename) as ddb:\n",

--- a/src/connectivity_search_PathCount_table/get_table.ipynb
+++ b/src/connectivity_search_PathCount_table/get_table.ipynb
@@ -22,7 +22,6 @@
    "source": [
     "import gzip\n",
     "import pathlib\n",
-    "from typing import List, Optional\n",
     "\n",
     "import duckdb\n",
     "import requests\n",

--- a/src/connectivity_search_PathCount_table/get_table.py
+++ b/src/connectivity_search_PathCount_table/get_table.py
@@ -1,0 +1,137 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# # Gather Connectivity Search `PathCount` Table
+#
+# Negar mentioned needing data from a PostgreSQL database archive, `connectivity-search-pg_dump.sql.gz`, which was created as part of https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .
+# The archive is available under https://zenodo.org/records/3978766 . Only the `PathCount` Table is needed in order to extract single metapaths at a time (needed for other work).
+#                                                                                                                   This PR was mentioned as a resource in case it's needed greenelab/connectivity-search-backend#79 .
+#                                                                                                                                                                                                            
+
+# +
+import gzip
+import pathlib
+from typing import List, Optional
+
+import duckdb
+import requests
+from pyarrow import parquet
+
+from hetionet_utils.sql import extract_and_write_sql_block
+
+# create the data dir
+pathlib.Path("data").mkdir(exist_ok=True)
+
+# url for source data
+url = "https://zenodo.org/records/3978766/files/connectivity-search-pg_dump.sql.gz?download=1"
+# local archive file location
+sql_file = "data/connectivity-search-pg_dump.sql.gz"
+# table which is targeted within the sql archive above
+target_table_name = "public.dj_hetmech_app_pathcount"
+# duckdb filename
+duckdb_filename = "data/connectivity-search.duckdb"
+
+# +
+# gather postgresql database archive
+
+# if the file doesn't exist, download it
+if not pathlib.Path(sql_file).exists():
+    # Download the file in streaming mode
+    response = requests.get(url, stream=True)
+    response.raise_for_status()  # Check if the request was successful
+
+    # Write the response content to a file in chunks
+    with open(output_file, "wb") as file:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                file.write(chunk)
+
+pathlib.Path(sql_file).exists()
+# -
+
+# show the tables
+count = 0
+with gzip.open(sql_file, "rt") as f:
+    for line in f:
+        # seek table creation lines
+        if "CREATE TABLE" in line:
+            print(line)
+            count += 1
+            # there are roughly 15 tables
+            # so we break here to avoid further processing
+            if count == 15:
+                break
+
+# gather the create table statement
+extract_and_write_sql_block(
+    sql_file=sql_file,
+    sql_start=f"CREATE TABLE {target_table_name}",
+    sql_end=";",
+    output_file=(create_table_file := f"create_table.{target_table_name}.sql"),
+)
+
+# show the create table statement
+with open(create_table_file, "r") as create_file:
+    print("".join(create_file.readlines()))
+
+# gather the data for the table
+# note: we avoid printing the file below as it is
+# relatively large at ~14.3 GB.
+extract_and_write_sql_block(
+    sql_file=sql_file,
+    sql_start=f"COPY {target_table_name}",
+    sql_end="\\.",
+    output_file=f"copy_data.{target_table_name}.sql",
+)
+
+# create the table
+with duckdb.connect(duckdb_filename) as ddb:
+    ddb.execute(create_sql.replace("public.", ""))
+
+# remove the first and last line of the data to avoid conflicts with a load
+# note: we use sed from a macos terminal, which may vary from system to system.
+# sed was used here to help avoid unnecessary data duplication and complexity
+# in processing through python.
+# !sed -i '' '1d;$d' copy_data.public.dj_hetmech_app_pathcount.sql
+
+# # copy the data from the file to duckdb database
+# as tab-delimited file.
+with duckdb.connect(duckdb_filename) as ddb:
+    ddb.execute(
+        """
+        COPY dj_hetmech_app_pathcount
+        FROM 'copy_data.public.dj_hetmech_app_pathcount.sql'
+        (DELIMITER '\t', HEADER false);
+        """
+    )
+
+# +
+# read and export data to parquet for ease of use
+with duckdb.connect(duckdb_filename) as ddb:
+    tbl_pathcount = ddb.execute(
+        """
+        SELECT *
+        FROM dj_hetmech_app_pathcount
+        """
+    ).arrow()
+
+parquet.write_table(
+    table=tbl_pathcount,
+    where="data/dj_hetmech_app_pathcount.parquet",
+    # compress with zstd for higher compression than snappy
+    compression="zstd",
+)
+# -
+
+

--- a/src/connectivity_search_PathCount_table/get_table.py
+++ b/src/connectivity_search_PathCount_table/get_table.py
@@ -17,12 +17,11 @@
 # Negar mentioned needing data from a PostgreSQL database archive, `connectivity-search-pg_dump.sql.gz`, which was created as part of https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .
 # The archive is available under https://zenodo.org/records/3978766 . Only the `PathCount` Table is needed in order to extract single metapaths at a time (needed for other work).
 #                                                                                                                   This PR was mentioned as a resource in case it's needed greenelab/connectivity-search-backend#79 .
-#                                                                                                                                                                                                            
+#
 
 # +
 import gzip
 import pathlib
-from typing import List, Optional
 
 import duckdb
 import requests
@@ -133,5 +132,3 @@ parquet.write_table(
     compression="zstd",
 )
 # -
-
-

--- a/src/connectivity_search_PathCount_table/get_table.py
+++ b/src/connectivity_search_PathCount_table/get_table.py
@@ -14,10 +14,12 @@
 
 # # Gather Connectivity Search `PathCount` Table
 #
-# Negar mentioned needing data from a PostgreSQL database archive, `connectivity-search-pg_dump.sql.gz`, which was created as part of https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .
-# The archive is available under https://zenodo.org/records/3978766 . Only the `PathCount` Table is needed in order to extract single metapaths at a time (needed for other work).
-#                                                                                                                   This PR was mentioned as a resource in case it's needed greenelab/connectivity-search-backend#79 .
-#
+# Negar mentioned needing data from a PostgreSQL database archive,
+# `connectivity-search-pg_dump.sql.gz`, which was created as part of
+# https://github.com/greenelab/connectivity-search-backend/blob/main/README.md .
+# The archive is available under https://zenodo.org/records/3978766 .
+# Only the `PathCount` Table is needed in order to extract single metapaths
+# at a time (needed for other work).
 
 # +
 import gzip
@@ -33,11 +35,20 @@ from hetionet_utils.sql import extract_and_write_sql_block
 pathlib.Path("data").mkdir(exist_ok=True)
 
 # url for source data
-url = "https://zenodo.org/records/3978766/files/connectivity-search-pg_dump.sql.gz?download=1"
+url = (
+    "https://zenodo.org/records/3978766/files/"
+    "connectivity-search-pg_dump.sql.gz?download=1"
+)
+
 # local archive file location
 sql_file = "data/connectivity-search-pg_dump.sql.gz"
+
+# expected number of tables within dump
+expected_table_count = 15
+
 # table which is targeted within the sql archive above
 target_table_name = "public.dj_hetmech_app_pathcount"
+
 # duckdb filename
 duckdb_filename = "data/connectivity-search.duckdb"
 
@@ -48,10 +59,12 @@ duckdb_filename = "data/connectivity-search.duckdb"
 if not pathlib.Path(sql_file).exists():
     # Download the file in streaming mode
     response = requests.get(url, stream=True)
-    response.raise_for_status()  # Check if the request was successful
+
+    # Check if the request was successful
+    response.raise_for_status()
 
     # Write the response content to a file in chunks
-    with open(output_file, "wb") as file:
+    with open(sql_file, "wb") as file:
         for chunk in response.iter_content(chunk_size=8192):
             if chunk:
                 file.write(chunk)
@@ -69,7 +82,7 @@ with gzip.open(sql_file, "rt") as f:
             count += 1
             # there are roughly 15 tables
             # so we break here to avoid further processing
-            if count == 15:
+            if count == expected_table_count:
                 break
 
 # gather the create table statement
@@ -80,43 +93,67 @@ extract_and_write_sql_block(
     output_file=(create_table_file := f"create_table.{target_table_name}.sql"),
 )
 
+# +
 # show the create table statement
 with open(create_table_file, "r") as create_file:
-    print("".join(create_file.readlines()))
+    create_sql = "".join(create_file.readlines())
+
+print(create_sql)
+# -
 
 # gather the data for the table
-# note: we avoid printing the file below as it is
-# relatively large at ~14.3 GB.
 extract_and_write_sql_block(
     sql_file=sql_file,
     sql_start=f"COPY {target_table_name}",
     sql_end="\\.",
-    output_file=f"copy_data.{target_table_name}.sql",
+    output_file=(copy_data_file := f"copy_data.{target_table_name}.sql"),
 )
+
+# +
+# replace the first and last lines of the copy file
+# as these are the header and data termination lines
+# which have no actual values.
+input_file = pathlib.Path(copy_data_file)
+# Temporary file with .tmp extension
+temp_file = input_file.with_suffix(".tmp")
+
+with input_file.open("r") as infile, temp_file.open("w") as outfile:
+    # Skip the first line
+    first_line = next(infile, None)
+
+    # Only proceed if the file is not empty
+    if first_line is not None:
+        # Start with the second line
+        prev_line = next(infile, None)
+        for line in infile:
+            # Write the previous line
+            outfile.write(prev_line)
+            # Update the previous line buffer
+            prev_line = line
+
+        # Note: the last line is in `prev_line` and is not written
+
+# Replace the original file with the temporary file
+temp_file.replace(input_file)
+# -
 
 # create the table
 with duckdb.connect(duckdb_filename) as ddb:
     ddb.execute(create_sql.replace("public.", ""))
 
-# remove the first and last line of the data to avoid conflicts with a load
-# note: we use sed from a macos terminal, which may vary from system to system.
-# sed was used here to help avoid unnecessary data duplication and complexity
-# in processing through python.
-# !sed -i '' '1d;$d' copy_data.public.dj_hetmech_app_pathcount.sql
-
 # # copy the data from the file to duckdb database
 # as tab-delimited file.
 with duckdb.connect(duckdb_filename) as ddb:
     ddb.execute(
-        """
+        f"""
         COPY dj_hetmech_app_pathcount
-        FROM 'copy_data.public.dj_hetmech_app_pathcount.sql'
+        FROM '{copy_data_file}'
         (DELIMITER '\t', HEADER false);
         """
     )
 
 # +
-# read and export data to parquet for ease of use
+# read and export data to parquet for simpler use
 with duckdb.connect(duckdb_filename) as ddb:
     tbl_pathcount = ddb.execute(
         """
@@ -131,4 +168,3 @@ parquet.write_table(
     # compress with zstd for higher compression than snappy
     compression="zstd",
 )
-# -

--- a/src/hetionet_utils/sql.py
+++ b/src/hetionet_utils/sql.py
@@ -1,9 +1,9 @@
-
 """
 Module for dealing with SQL-specific operations
 """
 
 import gzip
+
 
 def extract_and_write_sql_block(
     sql_file: str, sql_start: str, sql_end: str, output_file: str

--- a/src/hetionet_utils/sql.py
+++ b/src/hetionet_utils/sql.py
@@ -1,0 +1,37 @@
+
+"""
+Module for dealing with SQL-specific operations
+"""
+
+import gzip
+
+def extract_and_write_sql_block(
+    sql_file: str, sql_start: str, sql_end: str, output_file: str
+) -> bool:
+    """
+    Extracts a block of SQL statements from a compressed SQL dump file
+    and writes it to a specified output file.
+
+    Args:
+        sql_file (str): The path to the compressed SQL dump file (e.g., .sql.gz).
+        sql_start (str): The start pattern to identify the beginning of the SQL block.
+        sql_end (str): The end pattern to identify the end of the SQL block.
+        output_file (str): The path to the output file where the block will be written.
+
+    Returns:
+        bool: True if the SQL block was successfully written to the file, False if the block was not found.
+    """
+    with gzip.open(sql_file, "rt") as f:
+        in_sql_block = False  # Flag to track whether we are inside the block
+        with open(output_file, "w") as out_file:
+            for line in f:
+                if sql_start in line:
+                    in_sql_block = True  # Start collecting the SQL block
+
+                if in_sql_block:
+                    out_file.write(line)  # Write each line directly to the output file
+
+                if in_sql_block and sql_end in line:  # End of the SQL block
+                    return output_file  # Block successfully written
+
+    return None  # Return False if no block was found

--- a/src/hetionet_utils/sql.py
+++ b/src/hetionet_utils/sql.py
@@ -13,25 +13,36 @@ def extract_and_write_sql_block(
     and writes it to a specified output file.
 
     Args:
-        sql_file (str): The path to the compressed SQL dump file (e.g., .sql.gz).
-        sql_start (str): The start pattern to identify the beginning of the SQL block.
-        sql_end (str): The end pattern to identify the end of the SQL block.
-        output_file (str): The path to the output file where the block will be written.
+        sql_file (str):
+            The path to the compressed SQL dump file (e.g., .sql.gz).
+        sql_start (str):
+            The start pattern to identify the beginning of the SQL block.
+        sql_end (str):
+            The end pattern to identify the end of the SQL block.
+        output_file (str):
+            The path to the output file where the block will be written.
 
     Returns:
-        bool: True if the SQL block was successfully written to the file, False if the block was not found.
+        bool:
+            True if the SQL block was successfully written to the file,
+            False if the block was not found or incomplete.
     """
     with gzip.open(sql_file, "rt") as f:
         in_sql_block = False  # Flag to track whether we are inside the block
-        with open(output_file, "w") as out_file:
-            for line in f:
-                if sql_start in line:
-                    in_sql_block = True  # Start collecting the SQL block
+        temp_content = []  # Temporarily store the lines of the block
 
-                if in_sql_block:
-                    out_file.write(line)  # Write each line directly to the output file
+        for line in f:
+            if sql_start in line:
+                in_sql_block = True  # Start collecting the SQL block
 
-                if in_sql_block and sql_end in line:  # End of the SQL block
-                    return output_file  # Block successfully written
+            if in_sql_block:
+                temp_content.append(line)  # Collect the line
 
-    return None  # Return False if no block was found
+            if in_sql_block and sql_end in line:  # End of the SQL block
+                # Write the collected lines to the output file
+                with open(output_file, "w") as out_file:
+                    out_file.writelines(temp_content)
+                return True  # Block successfully written
+
+    # If we exit the loop without finding the end, the block is incomplete
+    return False

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,104 @@
+"""
+Tests for sql.py
+"""
+import pytest
+import tempfile
+import gzip
+import pathlib
+from typing import Optional
+from hetionet_utils.sql import extract_and_write_sql_block
+
+@pytest.mark.parametrize(
+    "sql_content, sql_start, sql_end, expected_output, expected_return",
+    [
+        # Case 1: Successful extraction
+        (
+            """CREATE TABLE test (
+                id INT PRIMARY KEY,
+                name TEXT
+            );
+            INSERT INTO test VALUES (1, 'Alice');""",
+            "CREATE TABLE test",
+            ");",
+            """CREATE TABLE test (
+                id INT PRIMARY KEY,
+                name TEXT
+            );""",
+            True,
+        ),
+        # Case 2: No matching start pattern
+        (
+            """DROP TABLE test;""",
+            "CREATE TABLE test",
+            ");",
+            None,
+            False,
+        ),
+        # Case 3: No matching end pattern
+        (
+            """CREATE TABLE test (
+                id INT PRIMARY KEY,
+                name TEXT
+            """,
+            "CREATE TABLE test",
+            ");",
+            None,
+            False,
+        ),
+        # Case 4: Empty file
+        (
+            "",
+            "CREATE TABLE test",
+            ");",
+            None,
+            False,
+        ),
+        # Case 5: Large content, valid block
+        (
+            "DROP TABLE old;\n" + ("-- filler\n" * 1000) + """
+            CREATE TABLE test (
+                id INT PRIMARY KEY,
+                name TEXT
+            );
+            """,
+            "CREATE TABLE test",
+            ");",
+            """CREATE TABLE test (
+                id INT PRIMARY KEY,
+                name TEXT
+            );""",
+            True,
+        ),
+    ],
+)
+def test_extract_and_write_sql_block(
+    sql_content: str, sql_start: str, sql_end: str, expected_output: Optional[str], expected_return: bool
+):
+    # Create temporary input and output files
+    temp_sql_path = pathlib.Path(tempfile.NamedTemporaryFile(delete=False, suffix=".sql.gz").name)
+    temp_output_path = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
+
+    try:
+        # Write the SQL content to a gzipped file
+        with gzip.open(temp_sql_path, "wt") as gzipped_file:
+            gzipped_file.write(sql_content)
+
+        # Run the function
+        result = extract_and_write_sql_block(str(temp_sql_path), sql_start, sql_end, str(temp_output_path))
+
+        # Assert the return value
+        assert result == expected_return
+
+        # If the block was found, assert the output content
+        if expected_output:
+            output_content = temp_output_path.read_text()
+            assert output_content.strip() == expected_output.strip()
+        else:
+            # If no block was found, the output file should be empty
+            output_content = temp_output_path.read_text()
+            assert output_content.strip() == ""
+
+    finally:
+        # Cleanup
+        temp_sql_path.unlink(missing_ok=True)
+        temp_output_path.unlink(missing_ok=True)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -84,11 +84,12 @@ def test_extract_and_write_sql_block(
     expected_output: Optional[str],
     expected_return: bool,
 ):
-    # Create temporary input and output files
-    temp_sql_path = pathlib.Path(
-        tempfile.NamedTemporaryFile(delete=False, suffix=".sql.gz").name
-    )
-    temp_output_path = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
+    # Use context managers for temporary files
+    with tempfile.NamedTemporaryFile(
+        delete=False, suffix=".sql.gz"
+    ) as temp_sql_file, tempfile.NamedTemporaryFile(delete=False) as temp_output_file:
+        temp_sql_path = pathlib.Path(temp_sql_file.name)
+        temp_output_path = pathlib.Path(temp_output_file.name)
 
     try:
         # Write the SQL content to a gzipped file

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,12 +1,16 @@
 """
 Tests for sql.py
 """
-import pytest
-import tempfile
+
 import gzip
 import pathlib
+import tempfile
 from typing import Optional
+
+import pytest
+
 from hetionet_utils.sql import extract_and_write_sql_block
+
 
 @pytest.mark.parametrize(
     "sql_content, sql_start, sql_end, expected_output, expected_return",
@@ -55,7 +59,9 @@ from hetionet_utils.sql import extract_and_write_sql_block
         ),
         # Case 5: Large content, valid block
         (
-            "DROP TABLE old;\n" + ("-- filler\n" * 1000) + """
+            "DROP TABLE old;\n"
+            + ("-- filler\n" * 1000)
+            + """
             CREATE TABLE test (
                 id INT PRIMARY KEY,
                 name TEXT
@@ -72,10 +78,16 @@ from hetionet_utils.sql import extract_and_write_sql_block
     ],
 )
 def test_extract_and_write_sql_block(
-    sql_content: str, sql_start: str, sql_end: str, expected_output: Optional[str], expected_return: bool
+    sql_content: str,
+    sql_start: str,
+    sql_end: str,
+    expected_output: Optional[str],
+    expected_return: bool,
 ):
     # Create temporary input and output files
-    temp_sql_path = pathlib.Path(tempfile.NamedTemporaryFile(delete=False, suffix=".sql.gz").name)
+    temp_sql_path = pathlib.Path(
+        tempfile.NamedTemporaryFile(delete=False, suffix=".sql.gz").name
+    )
     temp_output_path = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
 
     try:
@@ -84,7 +96,9 @@ def test_extract_and_write_sql_block(
             gzipped_file.write(sql_content)
 
         # Run the function
-        result = extract_and_write_sql_block(str(temp_sql_path), sql_start, sql_end, str(temp_output_path))
+        result = extract_and_write_sql_block(
+            str(temp_sql_path), sql_start, sql_end, str(temp_output_path)
+        )
 
         # Assert the return value
         assert result == expected_return

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,38 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/d7/ec014b351b6bb026d5f473b1d0ec6bd6ba40786b9abbf530b4c9041d9895/duckdb-1.1.3.tar.gz", hash = "sha256:68c3a46ab08836fe041d15dcbf838f74a990d551db47cb24ab1c4576fc19351c", size = 12240672 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/d0/96127582230183dc36f1209d5e8e67f54b3459b3b9794603305d816f350a/duckdb-1.1.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4f0e2e5a6f5a53b79aee20856c027046fba1d73ada6178ed8467f53c3877d5e0", size = 15469495 },
+    { url = "https://files.pythonhosted.org/packages/70/07/b78b435f8fe85c23ee2d49a01dc9599bb4a272c40f2a6bf67ff75958bdad/duckdb-1.1.3-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:911d58c22645bfca4a5a049ff53a0afd1537bc18fedb13bc440b2e5af3c46148", size = 32318595 },
+    { url = "https://files.pythonhosted.org/packages/6c/d8/253b3483fc554daf72503ba0f112404f75be6bbd7ca7047e804873cbb182/duckdb-1.1.3-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:c443d3d502335e69fc1e35295fcfd1108f72cb984af54c536adfd7875e79cee5", size = 16934057 },
+    { url = "https://files.pythonhosted.org/packages/f8/11/908a8fb73cef8304d3f4eab7f27cc489f6fd675f921d382c83c55253be86/duckdb-1.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a55169d2d2e2e88077d91d4875104b58de45eff6a17a59c7dc41562c73df4be", size = 18498214 },
+    { url = "https://files.pythonhosted.org/packages/bf/56/f627b6fcd4aa34015a15449d852ccb78d7cc6eda654aa20c1d378e99fa76/duckdb-1.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d0767ada9f06faa5afcf63eb7ba1befaccfbcfdac5ff86f0168c673dd1f47aa", size = 20149376 },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/c318dada688119b9ca975d431f9b38bde8dda41b6d18cc06e0dc52123788/duckdb-1.1.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51c6d79e05b4a0933672b1cacd6338f882158f45ef9903aef350c4427d9fc898", size = 18293289 },
+    { url = "https://files.pythonhosted.org/packages/37/8e/fd346444b270ffe52e06c1af1243eaae30ab651c1d59f51711e3502fd060/duckdb-1.1.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:183ac743f21c6a4d6adfd02b69013d5fd78e5e2cd2b4db023bc8a95457d4bc5d", size = 21622129 },
+    { url = "https://files.pythonhosted.org/packages/18/aa/804c1cf5077b6f17d752b23637d9ef53eaad77ea73ee43d4c12bff480e36/duckdb-1.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:a30dd599b8090ea6eafdfb5a9f1b872d78bac318b6914ada2d35c7974d643640", size = 10954756 },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/7ee500f4cff0d2a581c1afdf2c12f70ee3bf1a61041fea4d88934a35a7a3/duckdb-1.1.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:a433ae9e72c5f397c44abdaa3c781d94f94f4065bcbf99ecd39433058c64cb38", size = 15482881 },
+    { url = "https://files.pythonhosted.org/packages/28/16/dda10da6bde54562c3cb0002ca3b7678e3108fa73ac9b7509674a02c5249/duckdb-1.1.3-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:d08308e0a46c748d9c30f1d67ee1143e9c5ea3fbcccc27a47e115b19e7e78aa9", size = 32349440 },
+    { url = "https://files.pythonhosted.org/packages/2e/c2/06f7f7a51a1843c9384e1637abb6bbebc29367710ffccc7e7e52d72b3dd9/duckdb-1.1.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:5d57776539211e79b11e94f2f6d63de77885f23f14982e0fac066f2885fcf3ff", size = 16953473 },
+    { url = "https://files.pythonhosted.org/packages/1a/84/9991221ef7dde79d85231f20646e1b12d645490cd8be055589276f62847e/duckdb-1.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e59087dbbb63705f2483544e01cccf07d5b35afa58be8931b224f3221361d537", size = 18491915 },
+    { url = "https://files.pythonhosted.org/packages/aa/76/330fe16f12b7ddda0c664ba9869f3afbc8773dbe17ae750121d407dc0f37/duckdb-1.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ebf5f60ddbd65c13e77cddb85fe4af671d31b851f125a4d002a313696af43f1", size = 20150288 },
+    { url = "https://files.pythonhosted.org/packages/c4/88/e4b08b7a5d08c0f65f6c7a6594de64431ce7df38d7258511417ba7989ad3/duckdb-1.1.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4ef7ba97a65bd39d66f2a7080e6fb60e7c3e41d4c1e19245f90f53b98e3ac32", size = 18296560 },
+    { url = "https://files.pythonhosted.org/packages/1a/32/011e6e3ce14375a1ba01a588c119ad82be757f847c6b60207e0762d9ec3a/duckdb-1.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f58db1b65593ff796c8ea6e63e2e144c944dd3d51c8d8e40dffa7f41693d35d3", size = 21635270 },
+    { url = "https://files.pythonhosted.org/packages/f2/eb/58d4e0eccdc7b3523c062d008ad9eef28edccf88591d1a78659c809fe6e8/duckdb-1.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:e86006958e84c5c02f08f9b96f4bc26990514eab329b1b4f71049b3727ce5989", size = 10955715 },
+    { url = "https://files.pythonhosted.org/packages/81/d1/2462492531d4715b2ede272a26519b37f21cf3f8c85b3eb88da5b7be81d8/duckdb-1.1.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:0897f83c09356206ce462f62157ce064961a5348e31ccb2a557a7531d814e70e", size = 15483282 },
+    { url = "https://files.pythonhosted.org/packages/af/a5/ec595aa223b911a62f24393908a8eaf8e0ed1c7c07eca5008f22aab070bc/duckdb-1.1.3-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:cddc6c1a3b91dcc5f32493231b3ba98f51e6d3a44fe02839556db2b928087378", size = 32350342 },
+    { url = "https://files.pythonhosted.org/packages/08/27/e35116ab1ada5e54e52424e52d16ee9ae82db129025294e19c1d48a8b2b1/duckdb-1.1.3-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:1d9ab6143e73bcf17d62566e368c23f28aa544feddfd2d8eb50ef21034286f24", size = 16953863 },
+    { url = "https://files.pythonhosted.org/packages/0d/ac/f2db3969a56cd96a3ba78b0fd161939322fb134bd07c98ecc7a7015d3efa/duckdb-1.1.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f073d15d11a328f2e6d5964a704517e818e930800b7f3fa83adea47f23720d3", size = 18494301 },
+    { url = "https://files.pythonhosted.org/packages/cf/66/d0be7c9518b1b92185018bacd851f977a101c9818686f667bbf884abcfbc/duckdb-1.1.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5724fd8a49e24d730be34846b814b98ba7c304ca904fbdc98b47fa95c0b0cee", size = 20150992 },
+    { url = "https://files.pythonhosted.org/packages/47/ae/c2df66e3716705f48775e692a1b8accbf3dc6e2c27a0ae307fb4b063e115/duckdb-1.1.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51e7dbd968b393343b226ab3f3a7b5a68dee6d3fe59be9d802383bf916775cb8", size = 18297818 },
+    { url = "https://files.pythonhosted.org/packages/8e/7e/10310b754b7ec3349c411a0a88ecbf327c49b5714e3d35200e69c13fb093/duckdb-1.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00cca22df96aa3473fe4584f84888e2cf1c516e8c2dd837210daec44eadba586", size = 21635169 },
+    { url = "https://files.pythonhosted.org/packages/83/be/46c0b89c9d4e1ba90af9bc184e88672c04d420d41342e4dc359c78d05981/duckdb-1.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:77f26884c7b807c7edd07f95cf0b00e6d47f0de4a534ac1706a58f8bc70d0d31", size = 10955826 },
+]
+
+[[package]]
 name = "executing"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -455,10 +487,11 @@ wheels = [
 
 [[package]]
 name = "hetnet-analysis"
-version = "0.1.dev8+g4a7cf58.d20241108"
+version = "0.1.dev4+gdbe525a.d20241114"
 source = { editable = "." }
 dependencies = [
     { name = "black" },
+    { name = "duckdb" },
     { name = "hetmatpy" },
     { name = "ipywidgets" },
     { name = "isort" },
@@ -482,6 +515,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = ">=24.10" },
+    { name = "duckdb", specifier = ">=1.1.3" },
     { name = "hetmatpy", specifier = ">=0.1" },
     { name = "ipywidgets", specifier = ">=8.1.5" },
     { name = "isort", specifier = ">=5.13.2" },


### PR DESCRIPTION
This PR adds an extraction of the Connectivity Search PathCount table. I attempted to use the SQL credentials under https://github.com/greenelab/connectivity-search-backend?tab=readme-ov-file#database but I found that my query would hang indefinitely when attempting to access table `dj_hetmech_app_pathcount` (this may have been user error, I'm unsure). As a result my efforts here surrounded using the SQL statement backups. I tried to focus on extracting only the `dj_hetmech_app_pathcount` table and avoided unnecessary data loading into a full PostgreSQL database in order to keep things lightweight and avoid potentially larger than system resource consumption or cost (mostly storage). 

To avoid a full data extraction of the database I filtered the SQL backup statements to create and then populate a single table within a DuckDB database (`pg_restore` offers a single table ingest but only if the archive file is non-text/SQL, so again, I avoided using PostgreSQL directly). Then, to simplify the data access further, I extract the table from the database as a Parquet table. I plan to share along the results directly via email but this code is also able to generate the results where needed.

CC @NegarJanani @cgreene 